### PR TITLE
Bind to all interfaces

### DIFF
--- a/chapter03-1/src/main.rs
+++ b/chapter03-1/src/main.rs
@@ -11,7 +11,14 @@ async fn main() -> Result<(), anyhow::Error> {
         .await
         .map_err(anyhow::Error::from)
         .with_context(|| "Failed to connect to Postgres.")?;
-    let address = format!("0.0.0.0:{}", configuration.application_port);
+
+    // Here we choose to bind explicitly to localhost, 127.0.0.1, for security
+    // reasons. This binding may cause issues in some environments. For example,
+    // it causes connectivity issues running in WSL2, where you cannot reach the
+    // server when it is bound to WSL2's localhost interface. As a workaround,
+    // you can choose to bind to all interfaces, 0.0.0.0, instead, but be aware
+    // of the security implications when you expose the server on all interfaces.
+    let address = format!("127.0.0.1:{}", configuration.application_port);
     let listener = TcpListener::bind(address)?;
     run(listener, connection_pool)?.await?;
     Ok(())

--- a/chapter03-1/src/main.rs
+++ b/chapter03-1/src/main.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .await
         .map_err(anyhow::Error::from)
         .with_context(|| "Failed to connect to Postgres.")?;
-    let address = format!("127.0.0.1:{}", configuration.application_port);
+    let address = format!("0.0.0.0:{}", configuration.application_port);
     let listener = TcpListener::bind(address)?;
     run(listener, connection_pool)?.await?;
     Ok(())


### PR DESCRIPTION
When running under WSL2, binding only to localhost via the 127.0.0.1 address
only lets you access the server from within WSL2 itself. It does not allow you
to access the server from Windows.

With this change, you can access the web server from the WSL ip address. You can
find your WSL ip address with

```
$ ip a | grep eth0
4: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    inet 192.168.161.12/20 brd 192.168.175.255 scope global eth0
```