### PR TITLE
remove duplicate request_id in subscription instrumentation

### DIFF
--- a/chapter04/src/routes/subscriptions.rs
+++ b/chapter04/src/routes/subscriptions.rs
@@ -13,7 +13,6 @@ pub struct SubscribeRequest {
     name = "Adding a new subscriber",
     skip(payload, pool),
     fields(
-        request_id=%Uuid::new_v4(),
         email = %payload.email,
         name = %payload.name
     )


### PR DESCRIPTION
Hi @LukeMathWalker 👋

I noticed when I was following along with chapter 4 that after adding the `tracing-actix-web` that automatically adds `request_id` to tracing spans, the code we had previously put together resulted in differing `request_id`s in the spans. The child span would overwrite the `request_id`, so thought it best to quickly PR an update to the code.

Currently:
```
{"v":0,"name":"zero2prod","msg":"[REQUEST - START]" ... "request_id":"21fec996-ace2-4000-b301-263e319a04c5"}
{"v":0,"name":"zero2prod","msg":"[ADDING A NEW SUBSCRIBER - START]" ... "request_id":"aaccef45-5a13-4693-9a69-5755cf7888bf"}
```

After removing the old `request_id` from the `subscriptions` endpoint instrumentation:
```
{"v":0,"name":"zero2prod","msg":"[REQUEST - START]" ... "request_id":"f575b3d2-27bc-40d7-a9b7-33589499755d"}
{"v":0,"name":"zero2prod","msg":"[ADDING A NEW SUBSCRIBER - START]" ... "request_id":"f575b3d2-27bc-40d7-a9b7-33589499755d"}
```

P.S _Thanks for the great series, really enjoying it_.