### PR TITLE
Remove root access from final docker image

### DIFF
--- a/chapter05/Dockerfile
+++ b/chapter05/Dockerfile
@@ -35,4 +35,9 @@ RUN apt-get update -y \
 COPY --from=builder /app/target/release/chapter05 zero2prod
 COPY configuration configuration
 ENV APP_ENVIRONMENT production
+
+RUN groupadd -r rust && useradd -r -s /bin/false -g rust rust
+RUN chown -R rust:rust /app
+USER rust
+
 ENTRYPOINT ["./zero2prod"]


### PR DESCRIPTION
This PR just removes the root access from the final docker image during the build process by creating a user `root` and assigning it access to only the `/app` directory. This may not be great for people who are unfamiliar with docker, however, I think it might be good to get people to practice good docker hygine :)