### PR TITLE
use locked dependencies when installing sqlx-cli

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Migrate database
         run: |
           sudo apt-get install libpq-dev -y
-          cargo install --version=0.5.1 sqlx-cli --no-default-features --features postgres
+          cargo install --version=0.5.1 --locked sqlx-cli --no-default-features --features postgres
           SKIP_DOCKER=true ./scripts/init_db.sh
       - uses: actions-rs/cargo@v1
         with:
@@ -81,7 +81,7 @@ jobs:
       - name: Migrate database
         run: |
           sudo apt-get install libpq-dev -y
-          cargo install --version=0.5.1 sqlx-cli --no-default-features --features postgres
+          cargo install --version=0.5.1 --locked sqlx-cli --no-default-features --features postgres
           SKIP_DOCKER=true ./scripts/init_db.sh
       - uses: actions-rs/clippy-check@v1
         with:
@@ -113,7 +113,7 @@ jobs:
       - name: Migrate database
         run: |
           sudo apt-get install libpq-dev -y
-          cargo install --version=0.5.1 sqlx-cli --no-default-features --features postgres
+          cargo install --version=0.5.1 --locked sqlx-cli --no-default-features --features postgres
           SKIP_DOCKER=true ./scripts/init_db.sh
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1


### PR DESCRIPTION
This change is needed to workaround an incompatibility in the latest
release of a deep dependency that causes a conflict in bitvec, see:
https://github.com/launchbadge/sqlx/issues/1048