### PR TITLE
Correcting chapter 5 link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can browse the project at end of previous chapters by switching to their ded
 - [Chapter 3, Part 0](https://github.com/LukeMathWalker/zero-to-production/tree/root-chapter-03-part0)
 - [Chapter 3, Part 1](https://github.com/LukeMathWalker/zero-to-production/tree/root-chapter-03-part1)
 - [Chapter 4](https://github.com/LukeMathWalker/zero-to-production/tree/root-chapter-04)
-- [Chapter 5](https://github.com/LukeMathWalker/zero-to-production/tree/root-chapter-05)
+- [Chapter 5](https://github.com/LukeMathWalker/zero-to-production/tree/root-chapter05)
 - [Chapter 6, Part 0](https://github.com/LukeMathWalker/zero-to-production/tree/root-chapter-06)
 - [Chapter 6, Part 1](https://github.com/LukeMathWalker/zero-to-production/tree/root-chapter-06-part1)
 - [Chapter 7, Part 0](https://github.com/LukeMathWalker/zero-to-production/tree/root-chapter-07-part0)


### PR DESCRIPTION
The link to the Chapter 5 snapshot was broken. It referred to `root-chapter-05` while the actual link has the last _hyphen_ omitted (`root-chapter05`).