### PR TITLE
Exit if dockerized postgres is already running

### DIFF
--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -14,12 +14,21 @@ DB_PORT="${POSTGRES_PORT:=5432}"
 # Allow to skip Docker if a dockerized Postgres database is already running
 if [[ -z "${SKIP_DOCKER}" ]]
 then
+  # if a postgres container is running, print instructions to kill it and exit
+  RUNNING_POSTGRES_CONTAINER=$(docker ps --filter 'name=postgres' --format '{{.ID}}')
+  if [[ -n $RUNNING_POSTGRES_CONTAINER ]]; then
+    echo >&2 "there is a postgres container already running, kill it with"
+    echo >&2 "    docker kill ${RUNNING_POSTGRES_CONTAINER}"
+    exit 1
+  fi
+
   # Launch postgres using Docker
   docker run \
       -e POSTGRES_USER=${DB_USER} \
       -e POSTGRES_PASSWORD=${DB_PASSWORD} \
       -e POSTGRES_DB=${DB_NAME} \
       -p "${DB_PORT}":5432 \
+      --name "postgres_$(date '+%s')" \
       -d postgres \
       postgres -N 1000
       # ^ Increased maximum number of connections for testing purposes


### PR DESCRIPTION
Working my way through the book and enjoying it so far! I updated the init_db script a little bit to create the postgres container with a "postgres_<timestamp>" name. This lets us check for an existing, running, postgres container and exit early if it already exists. It's a little more clear/explicit than the "port 5432 already in use" error message that results from rerunning the script, and it addresses the gotcha in footnote 30

Admittedly, my fix is a very nitpicky fix, but I figured I'd send it your way and see if you think it makes things a little more ergonomic.