### PR TITLE
Call `log_out` method when logging out from admin panel

### DIFF
--- a/src/routes/admin/logout.rs
+++ b/src/routes/admin/logout.rs
@@ -7,6 +7,7 @@ pub async fn log_out(session: TypedSession) -> Result<HttpResponse, actix_web::E
     if session.get_user_id().map_err(e500)?.is_none() {
         Ok(see_other("/login"))
     } else {
+        session.log_out();
         FlashMessage::info("You have successfully logged out.").send();
         Ok(see_other("/login"))
     }

--- a/tests/api/admin_dashboard.rs
+++ b/tests/api/admin_dashboard.rs
@@ -12,3 +12,41 @@ async fn you_must_be_logged_in_to_access_the_admin_password() {
     assert_eq!(response.status().as_u16(), 303);
     assert_eq!(response.headers().get("Location").unwrap(), "/login");
 }
+
+#[tokio::test]
+async fn logout_clears_session_state() {
+    // Arrange
+    let app = spawn_app().await;
+
+    // Act - Part 1 - Login
+    let login_body = serde_json::json!({
+        "username": &app.test_user.username,
+        "password": &app.test_user.password
+    });
+    let response = app.post_login(&login_body).await;
+    assert_eq!(response.status().as_u16(), 303);
+    assert_eq!(
+        response.headers().get("Location").unwrap(),
+        "/admin/dashboard"
+    );
+
+    // Act - Part 2 - Follow the redirect
+    let response = app.get_admin_dashboard().await;
+    let html_page = response.text().await.unwrap();
+    assert!(html_page.contains(&format!("Welcome {}", app.test_user.username)));
+
+    // Act - Part 3 - Logout
+    let response = app.post_logout().await;
+    assert_eq!(response.status().as_u16(), 303);
+    assert_eq!(response.headers().get("Location").unwrap(), "/login");
+
+    // Act - Part 4 - Follow the redirect
+    let response = app.get_login().await;
+    let html_page = response.text().await.unwrap();
+    assert!(html_page.contains(r#"<p><i>You have successfully logged out.</i></p>"#));
+
+    // Act - Part 5 - Attempt to load admin panel
+    let response = app.get_admin_dashboard().await;
+    assert_eq!(response.status().as_u16(), 303);
+    assert_eq!(response.headers().get("Location").unwrap(), "/login");
+}


### PR DESCRIPTION
Currently, the log-out link on the admin panel just redirects the user to the login form without purging the session state. I just added in a line here to exercise the `log_out` method from the session object on log-out to ensure the session is deleted.