### PR TITLE
Update command for installing sqlx-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ brew install michaeleisel/zld/zld
 ```
 
 ```
-cargo install --version=0.6.0 sqlx-cli --no-default-features --features postgres
+cargo install --version=0.6.0 sqlx-cli --no-default-features --features native-tls,postgres
 ```
 
 ## How to build


### PR DESCRIPTION
# What

Add required `native-tls` feature to the install command of sqlx-cli.

```bash
$ cargo install --version=0.6.0 sqlx-cli --no-default-features --features native-tls,postgres
```

# Why
The current command for installing sqlx-cli throws an error.

See issue here: https://github.com/launchbadge/sqlx/issues/1604

<img width="1480" alt="Screen Shot 2022-07-25 at 11 17 30 AM" src="https://user-images.githubusercontent.com/2592156/180814134-7f1da34e-6d85-41bf-a0e3-85f2990a70ef.png">

