### PR TITLE
Replaced 'cargo install' with 'cargo binstall'

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ There are also some OS-specific requirements.
 ### Windows
   
 ```bash
-cargo install -f cargo-binutils
+cargo binstall -f cargo-binutils
 rustup component add llvm-tools-preview
 ```
 
 ```
-cargo install --version="~0.6" sqlx-cli --no-default-features --features rustls,postgres
+cargo binstall --version="~0.6" sqlx-cli --no-default-features --features rustls,postgres
 ```
 
 ### Linux
@@ -59,7 +59,7 @@ sudo pacman -S lld clang postgresql
 ```
 
 ```
-cargo install --version="~0.6" sqlx-cli --no-default-features --features rustls,postgres
+cargo binstall --version="~0.6" sqlx-cli --no-default-features --features rustls,postgres
 ```
 
 ### MacOS
@@ -69,7 +69,7 @@ brew install michaeleisel/zld/zld
 ```
 
 ```
-cargo install --version="~0.6" sqlx-cli --no-default-features --features rustls,postgres
+cargo binstall --version="~0.6" sqlx-cli --no-default-features --features rustls,postgres
 ```
 
 ## How to build

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -10,7 +10,7 @@ fi
 if ! [ -x "$(command -v sqlx)" ]; then
   echo >&2 "Error: sqlx is not installed."
   echo >&2 "Use:"
-  echo >&2 "    cargo install --version='~0.6' sqlx-cli --no-default-features --features rustls,postgres"
+  echo >&2 "    cargo binstall --version='~0.6' sqlx-cli --no-default-features --features rustls,postgres"
   echo >&2 "to install it."
   exit 1
 fi


### PR DESCRIPTION
*Issue #, if available:*
>[179](https://github.com/LukeMathWalker/zero-to-production/issues/179)
> `cargo install` requires unnecessary compilation time and electricity use - when there is a new tool that can save that time.

*Description of changes:*
`cargo binstall` replaces `cargo install` to download project-dependent binaries - saving compilation time and electricity use.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
