### PR TITLE
Update Cargo.toml, remove redundant reqwest dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,4 @@ quickcheck_macros = "0.9.1"
 fake = "~2.3.0"
 wiremock = "0.5"
 serde_json = "1.0.61"
-reqwest = { version = "0.11", features = ["json"] }
 once_cell = "1.7.2"


### PR DESCRIPTION
avoid duplication as it's already in the main dependencies so no need for it in the dev-dependency

quoting the book at chapter 7.2.2 page 168
[dependencies]
# [...]
# We need the `json` feature flag to serialize/deserialize JSON payloads reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] } [dev-dependencies]
# Remove `reqwest`'s entry from this list
# [...]

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
