### PR TITLE
Updating health_check to allow app user access to integration test tables

### DIFF
--- a/tests/health_check.rs
+++ b/tests/health_check.rs
@@ -43,6 +43,12 @@ pub async fn configure_database(config: &DatabaseSettings) -> PgPool {
         .await
         .expect("Failed to create database.");
 
+    //In current version of Postgres we need to give the app user ownership of the database to access it.
+    connection
+        .execute(format!(r#"ALTER DATABASE "{}" OWNER TO "{}";"#, config.database_name, config.username).as_str())
+        .await
+        .expect("Failed to change ownership.");
+
     // Migrate database
     let connection_pool = PgPool::connect(&config.connection_string())
         .await


### PR DESCRIPTION
Following your guide and using your Github repo, the tests at the end of chapter 3 will not work because Postgres spits back an error stating that app user does not have permissions to migrate. This is fixed by changing the ownership of the integration table to be the app user.