### PR TITLE
Update linker settings for Mac

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,4 +11,4 @@ rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/opt/llvm/bin/ld64.lld"]
+rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/opt/lld/bin/ld64.lld"]


### PR DESCRIPTION
Brew now separates the lld and llvm installs, so the user needs to `brew install lld` and update the directory to the lld directory from llvm to work on Mac.